### PR TITLE
ch347hw: fix I2CWriteByte ACK on CH347

### DIFF
--- a/software/ch347hw.pas
+++ b/software/ch347hw.pas
@@ -253,7 +253,7 @@ begin
   if not FDevOpened then Exit;
 
   mBuffer[0] := mCH341A_CMD_I2C_STREAM;
-  mBuffer[1] := mCH341A_CMD_I2C_STM_OUT or 1;
+  mBuffer[1] := mCH341A_CMD_I2C_STM_OUT;
   mBuffer[2] := data;
   mBuffer[3] := mCH341A_CMD_I2C_STM_END;
   mLength := 4;


### PR DESCRIPTION
## Problem

On CH347, I2C operations get stuck: the busy-poll loop in WriteFlashI2C / EraseFlashI2C never exits, writes hang, and if the user cancels the operation the slave device holds SDA low until the bus is power-cycled. The pre-read busy check also always reports "no answer", so reads can hang too.

## Root cause

Commit 29d9745 ("Fixed I2CWriteByte/I2CReadByte on CH347") changed I2CWriteByte to send `mCH341A_CMD_I2C_STM_OUT or 1`. For STM_IN the `or 1` bit is the ACK-after-read flag and is correct, but for STM_OUT
bit 0 is not an ACK flag. With it set, the CH347 does not complete the ACK cycle for the written byte and the status byte read back is always 0x00, so `I2CWriteByte` always returns False, `UsbAspI2C_BUSY()` always returns True, and the polling loops spin forever.

## Fix

Send plain `mCH341A_CMD_I2C_STM_OUT` (0x80), as before 29d9745. The CH347 then completes the byte transfer with a proper ACK clock and returns the real ACK (1 = ACK, 0 = NAK), so busy polling works normally and a cancelled write no longer leaves the slave holding SDA.

## Verification

- Hardware: CH347F + FM24C16 (I2C FRAM), official CH347DLL.DLL
  (2023-10-17), official 2.1.2 runtime.
- With `or 1`: busy poll hangs reproducibly; cancel leaves SDA low.
- With `0x80`: full 2048-byte page writes complete and verify OK; a
  mid-write cancel leaves SDA high immediately.

## Notes

- There is a similar user report in #159 (CH347F I2C stuck); it may share the same root cause.